### PR TITLE
Fix version file URL property

### DIFF
--- a/ReleaseFolder/GameData/WildBlueIndustries/Mk-33/Mk33.version
+++ b/ReleaseFolder/GameData/WildBlueIndustries/Mk-33/Mk33.version
@@ -1,6 +1,6 @@
 {
     "NAME":"Mk-33",
-    "URL":"https://raw.githubusercontent.com/Angel-125/Mk-33/master/GameData/WildBlueIndustries/Mk-33/Mk33.version",
+    "URL":"https://github.com/Angel-125/Mk-33/raw/master/ReleaseFolder/GameData/WildBlueIndustries/Mk-33/Mk33.version",
     "DOWNLOAD":"https://github.com/Angel-125/Mk-33/releases",
     "GITHUB":
     {


### PR DESCRIPTION
The current URL path is a 404 because ReleaseFolder is omitted. Now it's fixed.

Tagging @Angel-125 to ensure GitHub sends notifications.

@DasSkelett has written a great tool for catching this kind of error before release:

- https://github.com/DasSkelett/AVC-VersionFileValidator